### PR TITLE
Create transaction from csv

### DIFF
--- a/lib/profile/__snapshots__/actions.test.ts.snap
+++ b/lib/profile/__snapshots__/actions.test.ts.snap
@@ -2,19 +2,13 @@
 
 exports[`settings actions import/export csv format creates new tags and txs 1`] = `
 Object {
-  "errorReason": undefined,
+  "errorReason": "-0.7 is not in a valid amount format",
   "profile": Object {},
   "tags": Object {
     "0": Object {
       "automatic": false,
       "id": 0,
       "name": "Tickets",
-      "uid": null,
-    },
-    "2": Object {
-      "automatic": false,
-      "id": 2,
-      "name": "Shopping",
       "uid": null,
     },
   },
@@ -33,19 +27,6 @@ Object {
       "type": "expense",
       "uid": null,
     },
-    "3": Object {
-      "amount": 0.7,
-      "currency": "EUR",
-      "dateTime": 2017-08-16T00:00:00.000Z,
-      "id": 3,
-      "note": "",
-      "repeating": "annually",
-      "tagIds": Array [
-        2,
-      ],
-      "type": "expense",
-      "uid": null,
-    },
   },
 }
 `;
@@ -55,37 +36,37 @@ Object {
   "errorReason": undefined,
   "profile": Object {},
   "tags": Object {
-    "4": Object {
+    "2": Object {
       "automatic": false,
-      "id": 4,
+      "id": 2,
       "name": "A",
       "uid": null,
     },
-    "5": Object {
+    "3": Object {
       "automatic": false,
-      "id": 5,
+      "id": 3,
       "name": "B",
       "uid": null,
     },
-    "6": Object {
+    "4": Object {
       "automatic": false,
-      "id": 6,
+      "id": 4,
       "name": "C",
       "uid": null,
     },
   },
   "transactions": Object {
-    "7": Object {
+    "5": Object {
       "amount": 1.56,
       "currency": "EUR",
       "dateTime": 2016-02-16T00:00:00.000Z,
-      "id": 7,
+      "id": 5,
       "note": "",
       "repeating": "monthly",
       "tagIds": Array [
+        2,
+        3,
         4,
-        5,
-        6,
       ],
       "type": "expense",
       "uid": null,
@@ -94,7 +75,4 @@ Object {
 }
 `;
 
-exports[`settings actions import/export csv format exporting imported txs yields identity 1`] = `
-"2017-08-19T00:00:00.000Z,-1,Travel|Tickets,,EUR,none
-2017-08-16T00:00:00.000Z,-0.7,Shopping,,EUR,monthly"
-`;
+exports[`settings actions import/export csv format exporting imported txs yields identity 1`] = `"2017-08-19T00:00:00.000Z,1,expense,Travel|Tickets,,EUR,none"`;

--- a/lib/profile/actions.test.ts
+++ b/lib/profile/actions.test.ts
@@ -21,28 +21,31 @@ describe('settings actions', () => {
       })
 
       test('checks for errors', () => {
-        const checkError = (input: string) => dataFromImportedCsvSel(input)(state).errorReason
+        const fileName = 'notTB'
+        const checkError = (input: string) => dataFromImportedCsvSel(input, fileName)(state).errorReason
 
         expect(checkError('')).toBe('Unexpected import error. Check whether the data are in correct format.')
 
-        expect(checkError('invalid_date,-1,Travel|Tickets,,EUR,none')).toBe('invalid_date is not a valid date')
-        expect(checkError('21.11.1999,-1,Travel|Tickets,,EUR,none')).toBe('21.11.1999 is not a valid date')
-        expect(checkError('2017.08.19T00:00:00Z,-1,Travel|Tickets,,EUR,none')).toBe(
+        expect(checkError('invalid_date,1,expense,Travel|Tickets,,EUR,none')).toBe('invalid_date is not a valid date')
+        expect(checkError('21.11.1999,1,expense,Travel|Tickets,,EUR,none')).toBe('21.11.1999 is not a valid date')
+        expect(checkError('2017.08.19T00:00:00Z,1,expense,Travel|Tickets,,EUR,none')).toBe(
           '2017.08.19T00:00:00Z is not a valid date'
         )
 
-        expect(checkError('2017-08-19T00:00:00Z,+2,Travel|Tickets,,EUR,none')).toBe(
+        expect(checkError('2017-08-19T00:00:00Z,+2,income,Travel|Tickets,,EUR,none')).toBe(
           '+2 is not in a valid amount format'
         )
-        expect(checkError('2017-08-19T00:00:00Z,-1.345,Travel|Tickets,,EUR,none')).toBe(
-          '-1.345 is not in a valid amount format'
+        expect(checkError('2017-08-19T00:00:00Z,1.345,expense,Travel|Tickets,,EUR,none')).toBe(
+          '1.345 is not in a valid amount format'
         )
 
-        expect(checkError('2017-08-19T00:00:00Z,2,,,EUR,none')).toBe('There must be at least one tag in a transaction')
+        expect(checkError('2017-08-19T00:00:00Z,2,income,,,EUR,none')).toBe(
+          'There must be at least one tag in a transaction'
+        )
 
-        expect(checkError('2017-08-19T00:00:00Z,2,Travel,note,$,none')).toBe('Invalid currency of a transaction')
+        expect(checkError('2017-08-19T00:00:00Z,2,income,Travel,note,$,none')).toBe('Invalid currency of a transaction')
 
-        expect(checkError('2017-08-19T00:00:00Z,-1,Travel|Tickets,,EUR,invalid_repeating')).toBe(
+        expect(checkError('2017-08-19T00:00:00Z,1,expense,Travel|Tickets,,EUR,invalid_repeating')).toBe(
           'Invalid repeating mode invalid_repeating'
         )
       })
@@ -52,12 +55,13 @@ describe('settings actions', () => {
           id1: { id: 'id1', name: 'Travel', uid: 'user_id', automatic: false },
         }
         const csv1 =
-          '2017-08-19T00:00:00Z,-1,Travel|Tickets,,EUR,none\n2017-08-16T00:00:00Z,-0.7,Shopping,,EUR,annually'
-        const csv2 = '2016-02-16T00:00:00Z,-1.56,A|B|C,,EUR,monthly'
+          '2017-08-19T00:00:00Z,1,expense,Travel|Tickets,,EUR,none\n2017-08-16T00:00:00Z,-0.7,Shopping,,EUR,annually'
+        const csv2 = '2016-02-16T00:00:00Z,1.56,expense,A|B|C,,EUR,monthly'
+        const fileName = 'notTB'
 
         // Travel tag should be reused from state
-        expect(dataFromImportedCsvSel(csv1)(state)).toMatchSnapshot()
-        expect(dataFromImportedCsvSel(csv2)(state)).toMatchSnapshot()
+        expect(dataFromImportedCsvSel(csv1, fileName)(state)).toMatchSnapshot()
+        expect(dataFromImportedCsvSel(csv2, fileName)(state)).toMatchSnapshot()
       })
 
       test('exporting imported txs yields identity', () => {
@@ -65,9 +69,9 @@ describe('settings actions', () => {
           id1: { id: 'id1', name: 'Travel', uid: 'user_id', automatic: false },
         }
         const csv =
-          '2017-08-19T00:00:00.000Z,-1,Travel|Tickets,,EUR,none\n2017-08-16T00:00:00.000Z,-0.7,Shopping,,EUR,monthly'
-
-        const imp = dataFromImportedCsvSel(csv)(state)
+          '2017-08-19T00:00:00.000Z,1,expense,Travel|Tickets,,EUR,none\n2017-08-16T00:00:00.000Z,-0.7,Shopping,,EUR,monthly'
+        const fileName = 'notTB'
+        const imp = dataFromImportedCsvSel(csv, fileName)(state)
         const newState: State = {
           ...state,
           transactions: keyBy(imp.transactions, 'id'),

--- a/lib/profile/actions.ts
+++ b/lib/profile/actions.ts
@@ -24,7 +24,7 @@ import {
 } from './importExportSelectors'
 
 const importData =
-  (file: File, dataSourceSel: (importData: string) => (state: State) => ImportedData): Thunk =>
+  (file: File, dataSourceSel: (importData: string, importFileName: string) => (state: State) => ImportedData): Thunk =>
   async (dispatch, getState) => {
     const userId = currentUserIdSel(getState())
 
@@ -34,7 +34,7 @@ const importData =
     }
 
     const fileContent = await file.text()
-    const { errorReason, tags, transactions, profile } = dataSourceSel(fileContent)(getState())
+    const { errorReason, tags, transactions, profile } = dataSourceSel(fileContent, file.name)(getState())
 
     if (errorReason) {
       dispatch(setSnackbarNotification(createErrorNotification(errorReason)))

--- a/lib/profile/importExportSelectors.ts
+++ b/lib/profile/importExportSelectors.ts
@@ -48,10 +48,10 @@ const serializableStateSel = createSelector(
  */
 export const csvFromDataSel = createSelector(serializableStateSel, ({ transactions, tags }) => {
   const lines = Object.values(transactions).map((tx) =>
-    // TODO: fix with type = transfer
     [
       tx.dateTime.toISOString(),
-      tx.type === 'expense' ? -tx.amount : tx.amount,
+      tx.amount,
+      tx.type,
       tx.tagIds.map((id) => tags[id].name).join('|'),
       tx.note,
       tx.currency,
@@ -66,42 +66,114 @@ export interface ImportedData extends SerializableState {
 }
 
 /**
+ * Changes dateTime format from dd.mm.yyyy to yyyy-mm-ddT00:00:00.000Z
+ *
+ * if note contains time in hh:mm:ss format, it returns yyyy.mm.ddThh:mm:ss.000
+ */
+const formatDateToIso = (date: string, note: string) => {
+  const dateWithDash = date.split('.').reverse().join('-')
+  const time = note.match(/\d\d:\d\d:\d\d/)
+  if (time === null) return dateWithDash + 'T00:00:00.000'
+  return dateWithDash + 'T' + time[0] + '.000'
+}
+
+const formatTbCvs = (importedCsv: string) => {
+  let errorReasonTB: string | undefined
+  const lines = importedCsv.trim().split('\n')
+  const formatedLines = lines.map(() => '').slice(1)
+  if (lines.length <= 1) errorReasonTB = 'Csv file has to contain at leats one line of data'
+  try {
+    for (const [index, line] of lines.slice(1).entries()) {
+      const tx = line.split(',')
+      const amount = (tx[2] + '.' + tx[3]).replace(/"/g, '')
+      if (tx.length < 15) {
+        errorReasonTB = 'Lines have to consist of at least 15 columns'
+      } else if (tx[0].match(/^\d\d.\d\d.\d\d\d\d$/) === null) {
+        errorReasonTB = tx[0] + ' is not a valid date'
+      } else if (amount.match(/^\d+(\.\d{1,2})?$/) === null) {
+        errorReasonTB = amount.replace('.', ',') + ' is not a valid amount format'
+      } else if (!Object.keys(CURRENCIES).includes(tx[4])) {
+        errorReasonTB = tx[4] + ' is an invalid currency'
+      } else if (tx[5] !== 'Kredit' && tx[5] !== 'Debet') {
+        errorReasonTB = 'Columns 5 has to be "Kredit" or "Debet" and it is ' + tx[5]
+      }
+
+      if (errorReasonTB) break
+
+      const formatedLine = Array(6) as string[]
+      formatedLine[0] = formatDateToIso(tx[0], tx[14])
+      formatedLine[1] = tx[5] === 'Kredit' ? amount : '-' + amount
+      formatedLine[2] = 'createdFromCSV'
+      formatedLine[3] = tx[14]
+      formatedLine[4] = tx[4]
+      formatedLine[5] = 'none'
+      formatedLines[index] = formatedLine.join(',')
+    }
+  } catch (e) {
+    errorReasonTB = 'Unexpected error while parsing CSV from TB'
+  }
+  return { formatedLines, errorReasonTB }
+}
+
+/**
  * Imported csv file must have the following column structure:
  *  1. date - in ISO 8601 format
  *  2. amount - 2 decimal places, negative values means expenses, positive are incomes
- *  3. tags - separated by '|' (pipe)
- *  4. note - optional
+ *  3. type - 'expense' or 'income' or 'transfer'
+ *  4. tags - separated by '|' (pipe)
+ *  5. note - optional
+ *  6. currency - currency value of transaction (see list of available currency values)
+ *  7. repeating - one of the supported repeating modes
+ *  other columns are ignored
+ *
+ * Or their name has to start with 'TB', then file must have the following column structure
+ *  1. date - in dd.mm.yyyy format
+ *  3. amount - part before decimal point
+ *  4. amount - part after decimal point
  *  5. currency - currency value of transaction (see list of available currency values)
- *  6. repeating - one of the supported repeating modes
+ *  6. type - 'Kredit' meaning income and 'Debet' expense
+ *  15. note - optional, if note includes time (hh:mm:ss), it will be used as transaction time
+ *  amount fields have to be in absolute numbers
  *  other columns are ignored
  */
-export const dataFromImportedCsvSel = (importedCsv: string) =>
+export const dataFromImportedCsvSel = (importedCsv: string, importedFileName: string) =>
   createSelector(currentUserIdSel, tagsSel, (userId, stateTags): ImportedData => {
-    const lines = importedCsv.trim().split('\n')
+    let lines: string[]
+    let errorReason: string | undefined
+    if (importedFileName.startsWith('TB')) {
+      const { formatedLines, errorReasonTB } = formatTbCvs(importedCsv)
+      lines = formatedLines
+      errorReason = errorReasonTB
+    } else {
+      lines = importedCsv.trim().split('\n')
+    }
     const txs: ObjectOf<Transaction> = {}
     const newTagsByName = new Map<string, Tag>()
     const stateTagsByName = Object.values(stateTags).reduce(
       (acc, tag) => ({ ...acc, [tag.name]: tag }),
       {} as ObjectOf<Tag>
     )
-    let errorReason: string | undefined
+
+    if (errorReason) return { errorReason, transactions: txs, tags: {}, profile: {} }
 
     try {
       for (const line of lines) {
         const t = line.split(',')
 
         const dt = deserializers.transactions.dateTime!(t[0])
-        const rawTags = t[2].trim()
+        const rawTags = t[3].trim()
         if (!isValidDate(dt)) {
           errorReason = `${t[0]} is not a valid date`
-        } else if (/^-?\d+(\.\d{1,2})?$/.exec(t[1]) === null) {
+        } else if (/^\d+(\.\d{1,2})?$/.exec(t[1]) === null) {
           errorReason = `${t[1]} is not in a valid amount format`
+        } else if (t[2] !== 'expense' && t[2] !== 'income' && t[2] !== 'transfer') {
+          errorReason = `type has to be "expense" or "income" or "transfer" not ${t[2]}`
         } else if (rawTags.length === 0) {
           errorReason = `There must be at least one tag in a transaction`
-        } else if (!Object.keys(CURRENCIES).find((value) => value === t[4])) {
+        } else if (!Object.keys(CURRENCIES).find((value) => value === t[5])) {
           errorReason = `Invalid currency of a transaction`
-        } else if (!Object.keys(RepeatingOptions).includes(t[5] as RepeatingOption)) {
-          errorReason = `Invalid repeating mode ${t[5]}`
+        } else if (!Object.keys(RepeatingOptions).includes(t[6] as RepeatingOption)) {
+          errorReason = `Invalid repeating mode ${t[6]}`
         }
 
         if (errorReason) {
@@ -124,11 +196,11 @@ export const dataFromImportedCsvSel = (importedCsv: string) =>
         const txId = uuid()
         txs[txId] = {
           id: txId,
-          amount: Math.abs(amount),
-          currency: t[4] as any as Currency,
+          amount: amount,
+          currency: t[5] as any as Currency,
           dateTime: dt,
-          type: amount < 0 ? 'expense' : 'income',
-          note: t[3],
+          type: t[2] as 'expense' | 'income' | 'transfer',
+          note: t[4],
           tagIds: splitTags.map((tag) => {
             if (newTagsByName.get(tag)) {
               return newTagsByName.get(tag)!.id
@@ -137,7 +209,7 @@ export const dataFromImportedCsvSel = (importedCsv: string) =>
             }
           }),
           uid: userId!,
-          repeating: t[5] as RepeatingOption,
+          repeating: t[6] as RepeatingOption,
         }
       }
     } catch (e) {


### PR DESCRIPTION
New possibility to create transactions from report from TB in csv format
+ fixed exporting/importing transactions to/from csv to work correctly with transfer transactions
+ adjusted unit test to changed structure of exported csv